### PR TITLE
adding request timeouts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,18 @@ principle and can be either set directly or via environment variables.
 
 All connections are established over HTTPS.
 
+Timeouts
+~~~~~~~~
+
+The client takes a timeout parameter, this is passed directly to the underlying
+requests object.
+
+.. code:: python
+    interfax = InterFAX(timeout=0.001)
+
+**More:**
+`documentation <http://docs.python-requests.org/en/master/user/quickstart/#timeouts>`
+
 Account
 -------
 
@@ -613,6 +625,7 @@ convenience the following methods are available.
     document.upload(0, 999, ".....binary data...." # Maps to the interfax.documents.upload method
     document.cancel() # Maps to the interfax.documents.cancel method
     document.id  # Extracts the ID from the URI (the API does not return the ID)
+
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,8 @@ All connections are established over HTTPS.
 Timeouts
 ~~~~~~~~
 
-The client takes a timeout parameter, this is passed directly to the underlying
-requests object.
+The client takes a timeout parameter, this is a floating point number of seconds
+for the client to wait between receiving data before issuing a timeout error.
 
 .. code:: python
     interfax = InterFAX(timeout=0.001)

--- a/interfax/client.py
+++ b/interfax/client.py
@@ -25,7 +25,7 @@ class InterFAX(object):
     USER_AGENT = 'InterFAX Python {0}'.format(__version__)
     DOMAIN = 'rest.interfax.net'
 
-    def __init__(self, username=None, password=None):
+    def __init__(self, username=None, password=None, timeout=None):
         username = username or environ.get('INTERFAX_USERNAME', None)
         password = password or environ.get('INTERFAX_PASSWORD', None)
 
@@ -39,6 +39,7 @@ class InterFAX(object):
 
         self.username = username
         self.password = password
+        self.timeout = timeout
 
     @cached_property
     def inbound(self):
@@ -82,6 +83,7 @@ class InterFAX(object):
 
     def _request(self, method, url, **kwargs):
         """Make a HTTP request."""
+        kwargs.setdefault('timeout', self.timeout)
         kwargs.setdefault('headers', {})
         kwargs['headers']['User-Agent'] = self.USER_AGENT
         kwargs['auth'] = (self.username, self.password)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,11 +26,19 @@ class TestInterFAX(object):
     def test___init__(self, fake):
         username = fake.pystr()
         password = fake.pystr()
+        timeout = fake.pyfloat()
+
+        client = InterFAX(username, password, timeout)
+
+        assert client.username == username
+        assert client.password == password
+        assert client.timeout == timeout
 
         client = InterFAX(username, password)
 
         assert client.username == username
         assert client.password == password
+        assert client.timeout is None
 
     def test__init__environ(self, fake):
         username = fake.pystr()
@@ -148,11 +156,13 @@ class TestInterFAX(object):
         kwargs = fake.pydict()
 
         self.client._parse_response = Mock()
+        self.client.timeout = fake.pyfloat()
 
         with patch('interfax.client.request') as request:
             self.client._request(method, url, **kwargs)
 
         kwargs.setdefault('headers', {})
+        kwargs.setdefault('timeout', self.client.timeout)
         kwargs['headers']['User-Agent'] = self.client.USER_AGENT
         kwargs['auth'] = (self.client.username, self.client.password)
 


### PR DESCRIPTION
this adds an optional third param to the clients constructor which can be used to set the request timeout. see #7 for background.