### PR TITLE
Fix outbound.completed implementation

### DIFF
--- a/interfax/outbound.py
+++ b/interfax/outbound.py
@@ -49,7 +49,7 @@ class Outbound(object):
         """
         valid_keys = ['ids']
 
-        kwargs = {'ids': args}
+        kwargs = {'ids': ','.join(str(arg) for arg in args)}
 
         faxes = self.client.get('/outbound/faxes/completed', kwargs,
                                 valid_keys)

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -100,7 +100,7 @@ class TestOutbound(object):
 
         valid_keys = ['ids']
 
-        kwargs = {'ids': ids}
+        kwargs = {'ids': ','.join(str(id) for id in ids)}
 
         result = self.outbound.completed(*ids)
 


### PR DESCRIPTION
Prior to this commit, the url generated by client.outbound.completed()
included a url-encoded tuple where a comma-separated list was called
for, resulting in a HTTP 400 when called.

The method now pre-processes the arguments, generating the string that
is expected to be in the url.

Local testing shows that it now functions, and the relevant test has
been updated to match.